### PR TITLE
Use import maps for better caching

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -12,6 +12,7 @@
     <meta name="description" content="">
 
     {%- liquid
+      render 'importmap'
       render 'vite' with 'theme.css'
       render 'vite' with 'theme.js'
     -%}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prettier-plugin-tailwindcss": "^0.6.8",
     "tailwindcss": "^3.4.14",
     "vite": "^5.4.10",
-    "vite-plugin-shopify": "^3.0.1"
+    "vite-plugin-shopify": "^3.0.1",
+    "vite-plugin-shopify-import-maps": "^0.5.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ devDependencies:
   vite-plugin-shopify:
     specifier: ^3.0.1
     version: 3.0.1(vite@5.4.10)
+  vite-plugin-shopify-import-maps:
+    specifier: ^0.5.4
+    version: 0.5.4
 
 packages:
 
@@ -1921,6 +1924,10 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
+
+  /vite-plugin-shopify-import-maps@0.5.4:
+    resolution: {integrity: sha512-YvWdvPgtTUhMxMSPwczF7uHuG7yh2OBAEMOsmdnW52CMJXDf0n+5Yj+lkeLO+kjU8jo8jTlMGKRCtvUoTVFyGA==}
     dev: true
 
   /vite-plugin-shopify@3.0.1(vite@5.4.10):

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,15 +1,19 @@
 import { defineConfig } from 'vite';
 import shopify from 'vite-plugin-shopify';
+import importMaps from 'vite-plugin-shopify-import-maps';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [shopify({ snippetFile: 'vite.liquid' })],
+  plugins: [
+    shopify({ snippetFile: 'vite.liquid', versionNumbers: true }),
+    importMaps({ bareModules: true }),
+  ],
   build: {
     rollupOptions: {
       output: {
-        entryFileNames: '[name].[hash].min.js',
-        chunkFileNames: '[name].[hash].min.js',
-        assetFileNames: '[name].[hash].min[extname]',
+        entryFileNames: '[name].js',
+        chunkFileNames: '[name].js',
+        assetFileNames: '[name].[ext]',
       },
     },
   },


### PR DESCRIPTION
Added [vite-plugin-shopify-import-maps](https://github.com/slavamak/vite-plugin-shopify-import-maps/tree/main) to avoid [cascading cache invalidation](https://philipwalton.com/articles/cascading-cache-invalidation/)