### PR TITLE
Configure CORS

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,14 @@ export default defineConfig({
     tailwindcss(),
     importMaps({ bareModules: true }),
   ],
+  server: {
+    cors: {
+      origin: [
+        /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/,
+        'https://johns-apparel.myshopify.com', // Store URL
+      ],
+    },
+  },
   build: {
     minify: false,
     rollupOptions: {


### PR DESCRIPTION
Vite recently patched a vulnerability in their dev server ([GHSA-vg6x-rcgg-rjx6](https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6)).

Now it's recommended to limit [server.cors.origin](https://vite.dev/config/server-options.html#server-cors) to trusted origins.